### PR TITLE
Fix AttributeError in Django 1.11 when saving.

### DIFF
--- a/filebrowser/fields.py
+++ b/filebrowser/fields.py
@@ -81,7 +81,7 @@ class FileBrowseFormField(forms.CharField):
 
     def clean(self, value):
         value = super(FileBrowseFormField, self).clean(value)
-        if value == '':
+        if not value:
             return value
         file_extension = os.path.splitext(value)[1].lower()
         if self.extensions and file_extension not in self.extensions:


### PR DESCRIPTION
Tests passed on Django 1.11.2 and Filebrowser 3.7.1

```
Exception Type: AttributeError
Exception Value: 'NoneType' object has no attribute 'rfind'
```